### PR TITLE
Changes for Ansible 2.8 compatibility

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,9 @@
+- name: Ensure that required variables are defined.
+  assert:
+    that:
+      - aem_service_name is defined
+      - aem_service_port is defined
+
 - name: Include service manager specific variables.
   include_vars: "{{ item }}"
   with_first_found:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,7 @@
     that:
       - aem_service_name is defined
       - aem_service_port is defined
+    fail_msg: "'aem_service_name' and 'aem_service_port' must be defined"
 
 - name: Include service manager specific variables.
   include_vars: "{{ item }}"

--- a/tasks/start_aem.yml
+++ b/tasks/start_aem.yml
@@ -28,6 +28,5 @@
   until: result.content.find("QUICKSTART_HOMEPAGE") != -1
   retries: "{{ aem_service_timeout // 10 }}"
   delay: 10
-  when: aem_service_start_result_escalated.changed or aem_service_start_result_restricted.changed
   tags:
     - skip_ansible_lint

--- a/tasks/start_aem.yml
+++ b/tasks/start_aem.yml
@@ -20,7 +20,7 @@
 
   when: aem_service_restricted_mode
 
-- name: "Wait for AEM startup."
+- name: "Wait for AEM startup. [{{ inventory_hostname }}]"
   uri:
     url: "{{ aem_service_login_url }}"
     return_content: yes

--- a/tasks/start_aem.yml
+++ b/tasks/start_aem.yml
@@ -20,7 +20,7 @@
 
   when: aem_service_restricted_mode
 
-- name: "Wait for AEM startup. [{{ inventory_hostname }}]"
+- name: "Wait for AEM startup."
   uri:
     url: "{{ aem_service_login_url }}"
     return_content: yes

--- a/tasks/stop_aem.yml
+++ b/tasks/stop_aem.yml
@@ -20,13 +20,12 @@
 
   when: aem_service_restricted_mode
 
-- name: Wait for AEM shutdown.
+- name: "Wait for AEM shutdown. [{{ inventory_hostname }}]"
   wait_for:
     port: "{{ aem_service_port }}"
     state: stopped
     delay: 0
     sleep: 10
     timeout: "{{ aem_service_timeout }}"
-  when: aem_service_stop_result_escalated.changed or aem_service_stop_result_restricted.changed
   tags:
     - skip_ansible_lint


### PR DESCRIPTION
This PR add the following changes:
* ensure that `aem_service_name` and `aem_service_port ` are defined before performing any action
* Always check for startup and shutdown complete, even when the service state has not changed
* Add `inventory_hostname` in wait for shutdown task name

These changes are not really important for the Ansible 2.8 kompatibility but where found during testing